### PR TITLE
Fixed mobile menu scrolling & full item visibility in Navbar

### DIFF
--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -88,7 +88,15 @@ const Navbar = ({ isAuthenticated, onLogout, user }) => {
   };
 
   const toggleMobileMenu = () => {
-    setIsMobileMenuOpen(!isMobileMenuOpen);
+    setIsMobileMenuOpen((prev) => {
+     const newState = !prev;
+     if (newState) {
+       document.body.classList.add("no-scroll");
+    } else {
+        document.body.classList.remove("no-scroll");
+    }
+    return newState;
+   });
   };
   
   const toggleProfileMenu = () => {
@@ -217,8 +225,8 @@ const Navbar = ({ isAuthenticated, onLogout, user }) => {
         </div>
 
         {/* Mobile Menu */}
-        <div className={`lg:hidden transition-all duration-300 overflow-hidden ${isMobileMenuOpen ? 'max-h-96 opacity-100' : 'max-h-0 opacity-0'}`}>
-          <div className="px-4 pt-2 pb-4 space-y-1 bg-purple-900/95 backdrop-blur-sm border-t border-purple-700/30">
+        <div className={`lg:hidden transition-all duration-300 ${isMobileMenuOpen ? 'max-h-screen opacity-100' : 'max-h-0 opacity-0'}`}>
+          <div className="px-4 pt-2 pb-4 space-y-1 bg-purple-900/95 backdrop-blur-sm border-t border-purple-700/30 overflow-y-auto max-h-[calc(100vh-4rem)]">
             {navigationItems.map((item) => {
               const IconComponent = item.icon;
               const isActive = currentPage === item.id;


### PR DESCRIPTION
**Description:**
This PR fixes two issues in the mobile hamburger menu inside Navbar.jsx:

- Missing ResourceVault item – previously cut off due to limited height.
- Background scrolling – the page continued to scroll when the mobile menu was open.

**Changes Made:**

- Updated mobile menu container in Navbar.jsx to use max-h-screen and overflow-y-auto for proper scroll within the menu.
- Added no-scroll body class toggle when the menu opens/closes to prevent background page scrolling.

**Before:**

- Some menu items (e.g., ResourceVault, Sign-in) not visible on smaller screens.
- Scrolling affected the background page instead of the menu itself.

<img width="924" height="934" alt="Screenshot 2025-09-15 215057" src="https://github.com/user-attachments/assets/2cbdf808-e097-44a6-a041-d06040357eae" />

**After:**

- All menu items are fully visible (menu scrolls independently).
- Background page is locked when the menu is open.

<img width="731" height="902" alt="image" src="https://github.com/user-attachments/assets/fe3215dc-1493-42d8-9532-dfda3ec4c85d" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Mobile menu now prevents background page scrolling when opened, eliminating unintended page movement.
  - Menu content scrolls within the panel, staying within the viewport on smaller screens.
  - Improved height handling ensures reliable open/close behavior without clipped content.
  - Smoother transitions deliver a more consistent experience across devices and screen orientations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->