### PR TITLE
Add 'Back to Top' link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,3 +156,5 @@ This project is licensed under the MIT License.
 ⭐ Give Edgex a Star!
 If you love what we're building, star the repo and share it with your dev friends!
 Let’s make AI mentorship the new normal for Gen Z 💥
+
+[⬆️ Back to Top](#readme)


### PR DESCRIPTION
The "⬆️ Back to Top" link located at the bottom of the README

Steps to Reproduce:

Scroll to the bottom of the README.

Click the "Back to Top" link.

Expected Behavior:
Clicking the link should bring the reader back to the beginning of the README, allowing smoother navigation throughout the document.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Added a “Back to Top” link at the end of the README, preceded by a blank line.
  - Link targets the document’s main header anchor to allow one-click return to the top.
  - No other text, sections, or layout were altered; content remains unchanged.
  - Affects only README rendering in viewers like GitHub.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->